### PR TITLE
run with node rather than npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ node.js environment
 ## Usage
 
 1. `> npm install`
-2. `> npm run main.js & npm run resource.js`
+2. `> node main.js & node resource.js`
 3. Browse to localhost:3000
 4. Obtain a token using valid credentials (see fakeDatabase.js).
 5. Token is stored in the DOM.


### PR DESCRIPTION
got an error when initially running the project, realised there were no scripts in the package.json. When changed to run with node there are no errors.